### PR TITLE
Implement zd add metadata (#5)

### DIFF
--- a/src/zenodo_deposit/api.py
+++ b/src/zenodo_deposit/api.py
@@ -327,32 +327,29 @@ def upload(
     return deposition
 
 
-def update_metadata(
-    base_url: str, deposition_id: int, metadata: Dict, params: Dict
-) -> Dict:
+
+def update_metadata(base_url: str, deposition_id: int, metadata: Dict, params: Dict) -> Dict:
     """
-    Update metadata of the Zenodo deposition.
+    Update metadata for a deposition.
 
     Args:
         base_url (str): The base URL for the Zenodo API.
         deposition_id (int): The ID of the deposition.
-        metadata (Dict): The metadata to update in the deposition.
-        params (Dict): The parameters for the request, including the access token.
+        metadata (dict): The metadata to update.
+        params (dict): Parameters including access token.
 
     Returns:
-        Dict: The response from the Zenodo API.
+        dict: The updated deposition details.
     """
-    headers = {"Content-Type": "application/json"}
-    data = {"metadata": metadata}
-    response = requests.put(
+    logging.info(f"Updating metadata for deposition {deposition_id}")
+    r = requests.put(
         f"{base_url}/deposit/depositions/{deposition_id}",
         params=params,
-        data=json.dumps(data),
-        headers=headers,
+        json={"metadata": metadata},
     )
-    response.raise_for_status()
-    return response.json()
-
+    logging.debug(f"Response: {r.status_code} {r.json()}")
+    r.raise_for_status()
+    return r.json()
 
 def delete_deposition(base_url: str, deposition_id: int, params: Dict) -> Dict:
     """
@@ -364,14 +361,18 @@ def delete_deposition(base_url: str, deposition_id: int, params: Dict) -> Dict:
         params (Dict): The parameters for the request, including the access token.
 
     Returns:
-        Dict: The response from the Zenodo API.
+        Dict: Empty dict on success (204), or the API response on error.
+
+    Raises:
+        requests.exceptions.HTTPError: If the API request fails (e.g., 404, 403).
     """
     response = requests.delete(
         f"{base_url}/deposit/depositions/{deposition_id}", params=params
     )
     response.raise_for_status()
+    if response.status_code == 204:
+        return {}
     return response.json()
-
 
 def get_deposition(deposition_id: int, config: Dict, sandbox: bool = True) -> Dict:
     """

--- a/src/zenodo_deposit/config.py
+++ b/src/zenodo_deposit/config.py
@@ -3,6 +3,7 @@ import os
 from functools import lru_cache
 from typing import Dict
 import logging
+import copy
 
 logger = logging.getLogger(__name__)
 
@@ -11,9 +12,7 @@ default_zenodo: Dict[str, str] = {
     "ZENODO_SANDBOX_ACCESS_TOKEN": "Change me",
 }
 
-
 settings_name = ".zenodo-deposit-settings.toml"
-
 
 def first_file_that_exists(files):
     for file in files:
@@ -21,16 +20,18 @@ def first_file_that_exists(files):
             return file
     return None
 
-
 def read_config_file(file: str = None) -> Dict[str, Dict[str, str]]:
     """
     Read the config file, if given, else look in the standard locations
     will throw an error if the config file is not found, or it is invalid TOML
     """
+    logger.debug(f"Attempting to read config file: {file if file else 'default locations'}")
     if file:
         logger.info(f"Reading config file: {file}")
         with open(file, "rb") as f:
-            return toml.load(f)
+            config = toml.load(f)
+            logger.debug(f"Loaded config: {config}")
+            return config
     else:
         first_config = first_file_that_exists(
             [
@@ -41,9 +42,11 @@ def read_config_file(file: str = None) -> Dict[str, Dict[str, str]]:
         if first_config:
             logger.info(f"Reading config file: {first_config}")
             with open(first_config, "rb") as f:
-                return toml.load(f)
-    return {"zenodo": default_zenodo}
-
+                config = toml.load(f)
+                logger.debug(f"Loaded config: {config}")
+                return config
+    logger.debug("No config file found, using default_zenodo")
+    return {"zenodo": copy.deepcopy(default_zenodo)}
 
 @lru_cache(maxsize=32)
 def config_section(
@@ -53,16 +56,18 @@ def config_section(
     """
     Read a specific section from the configuration file, updating it with environment variables
     """
+    logger.debug(f"Reading section '{section}' from config file: {config_file}")
     config = read_config_file(config_file)
     config_section = config.get(section)
     if not config_section:
         raise ValueError(f"Section {section} not found in the configuration file")
-
+    config_section = copy.deepcopy(config_section)  # Prevent modifying original
+    logger.debug(f"Config section before env update: {config_section}")
     for key in config_section.keys():
         if key in os.environ:
             config_section[key] = os.environ[key]
+    logger.debug(f"Config section after env update: {config_section}")
     return config_section
-
 
 def zenodo_config(config_file=None) -> Dict[str, str]:
     """
@@ -70,28 +75,32 @@ def zenodo_config(config_file=None) -> Dict[str, str]:
     """
     return config_section(config_file, "zenodo")
 
-
 def validate_zenodo_config(config: Dict[str, str], use_sandbox: bool = False) -> bool:
     """
     Validate the configuration.
-    1. Ensure that the ZENODO_ACCESS_TOKEN or the ZENODO_SANDBOX_ACCESS_TOKEN is set
-    to something other than the default value.
+    Ensure that the ZENODO_ACCESS_TOKEN or ZENODO_SANDBOX_ACCESS_TOKEN is set
+    to a non-empty, non-default value.
     """
-    check1 = config.get("ZENODO_ACCESS_TOKEN") and (
-        config["ZENODO_ACCESS_TOKEN"] != default_zenodo["ZENODO_ACCESS_TOKEN"]
-    )
-    check2 = config.get("ZENODO_SANDBOX_ACCESS_TOKEN") and (
-        config["ZENODO_SANDBOX_ACCESS_TOKEN"]
-        != default_zenodo["ZENODO_SANDBOX_ACCESS_TOKEN"]
-    )
-    logger.debug(f"Config: {config}")
-    logger.debug(f"Check1: {check1}")
-    logger.debug(f"Check2: {check2}")
-    if not use_sandbox and not check1:
-        raise ValueError("ZENODO_ACCESS_TOKEN is not set in production environment")
-    if use_sandbox and not check2:
-        raise ValueError(
-            "ZENODO_SANDBOX_ACCESS_TOKEN is not set, sandbox being used. Config: "
-            + str(config)
-        )
+    logger.debug(f"Config module path: {__file__}")
+    logger.debug(f"Full config before validation: {config}")
+    logger.debug(f"Default zenodo config: {default_zenodo}")
+    if use_sandbox:
+        token = config.get("ZENODO_SANDBOX_ACCESS_TOKEN")
+        logger.debug(f"ZENODO_SANDBOX_ACCESS_TOKEN raw: {repr(token)}")
+        logger.debug(f"ZENODO_SANDBOX_ACCESS_TOKEN length: {len(token) if token else 0}")
+        logger.debug(f"ZENODO_SANDBOX_ACCESS_TOKEN stripped: {token.strip() if token else ''}")
+        if not token or token.strip() == "" or token.strip() == default_zenodo["ZENODO_SANDBOX_ACCESS_TOKEN"]:
+            raise ValueError(
+                f"ZENODO_SANDBOX_ACCESS_TOKEN is not set or invalid, sandbox being used. Config: {config}"
+            )
+    else:
+        token = config.get("ZENODO_ACCESS_TOKEN")
+        logger.debug(f"ZENODO_ACCESS_TOKEN raw: {repr(token)}")
+        logger.debug(f"ZENODO_ACCESS_TOKEN length: {len(token) if token else 0}")
+        logger.debug(f"ZENODO_ACCESS_TOKEN stripped: {token.strip() if token else ''}")
+        if not token or token.strip() == "" or token.strip() == default_zenodo["ZENODO_ACCESS_TOKEN"]:
+            raise ValueError(
+                f"ZENODO_ACCESS_TOKEN is not set or invalid in production environment. Config: {config}"
+            )
+    logger.debug("Config validation passed")
     return True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,10 +81,11 @@ def test_add_metadata(base_url, params, deposition_response):
         "creators": [{"name": "Doe, John", "affiliation": "Zenodo"}],
     }
 
-    with patch("requests.put") as mock_put:
+    with patch("requests.get") as mock_get, patch("requests.put") as mock_put:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"id": deposition_id, "metadata": {}}
         mock_put.return_value.status_code = 200
         mock_put.return_value.json.return_value = deposition_response
-
         response = add_metadata(base_url, deposition_id, metadata, params)
         assert response == deposition_response
 
@@ -127,7 +128,7 @@ def test_delete_deposition(base_url, params):
         mock_delete.return_value.status_code = 204
 
         response = delete_deposition(base_url, deposition_id, params)
-        assert response
+        assert response == {}  # Expect empty dict for 204 response
 
 
 def test_get_deposition(base_url, params, deposition_response):


### PR DESCRIPTION
Implements `zd add_metadata` CLI command to merge metadata with existing deposition metadata.
Enhanced `zd create` to support `--title`, `--description`, `--variable`, `--type`, `--keywords`, and `--metadata` options with variables. Updated `cli.py` with consistent docstrings and fixed metadata handling in `zd upload`. Tested in local and sandbox mode with metadata toml and variables.

fixes #5